### PR TITLE
Fixed a bug that caused an error when the compiler warning level was maximized.

### DIFF
--- a/src/utility/MFRC522.cpp
+++ b/src/utility/MFRC522.cpp
@@ -395,7 +395,7 @@ uint8_t MFRC522::PCD_CommunicateWithPICC(	uint8_t command,		///< The command to 
 										uint8_t rxAlign,		///< In: Defines the bit position in backData[0] for the first bit received. Default 0.
 										bool checkCRC		///< In: True => The last two bytes of the response is assumed to be a CRC_A that must be validated.
 									 ) {
-	uint8_t n, _validBits;
+	uint8_t n, _validBits = 0;
 	unsigned int i;
 
 	// Prepare values for BitFramingReg


### PR DESCRIPTION
There is an area within the MFRC522 library where uninitialized variables may be used.
This is causing an error when the compile warning level is set to maximum.
This pull request assigns an initial value of 0 to the corresponding variable.